### PR TITLE
fix: change build prefix to the right thing

### DIFF
--- a/com.obsproject.Studio.Plugin._3DEffect.yaml
+++ b/com.obsproject.Studio.Plugin._3DEffect.yaml
@@ -5,7 +5,7 @@ sdk: org.kde.Sdk//6.6
 build-extension: true
 separate-locales: false
 build-options:
-  prefix: /app/plugins/3DEffect
+  prefix: /app/plugins/_3DEffect
 modules:
   - name: 3d-effect
     buildsystem: cmake-ninja


### PR DESCRIPTION
This was messing up the plugin itself because the ID is `_3DEffect` and it was being mounted as `_3DEffect` on the sandbox, but the libraries and stuff were poiting to just `3DEffect`.

![image](https://github.com/user-attachments/assets/8df0b7b9-91e0-4401-88a9-65caebcc0572)
